### PR TITLE
#115 Add GitHub issue templates to the emfcloud repositories

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,9 @@
+---
+name: Bug Report
+about: Create a bug report to help us improve
+labels: bug
+---
+
+<!-- Please provide a detailed description of the bug and provide any additional information available. -->
+<!-- Additional information can be in the form of logs, screenshots, screencasts. -->
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Question
+    url:  https://github.com/eclipse-emfcloud/emfcloud/discussions
+    about: Please ask questions on the EMF.cloud discussions page.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,9 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: enhancement
+---
+
+<!-- Is your feature request related to a problem? Please describe -->
+<!-- Describe the solution you'd like -->
+<!-- Describe alternatives you've considered -->


### PR DESCRIPTION
Add GitHub issue templates to the repository, disable blank issues and add button that redirects to the emfcloud discussions board.

Part of eclipse-emfcloud/emfcloud#115