### PR TITLE
#26 Fix Jenkins build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ lib
 **/*-app/*
 !**/*-app/package.json
 plugins
+**/eslint.xml

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "prepare": "lerna run prepare",
+    "lint": "lerna run lint --",
     "watch": "lerna run --parallel watch",
     "start": "yarn --cwd example/browser-app start",
     "publish": "yarn && yarn publish:latest",


### PR DESCRIPTION
- Remove build retries
- Add code linting as separate pipeline step
- Add clean of yarn cache to fix sporadic build errors
- Add GitHub back reporting for ESLint

Fixes #26