### PR TITLE
#40 Use Theia's URI type in ModelserverAwareWidgetProvider

### DIFF
--- a/modelserver-jsonforms-property-view/package.json
+++ b/modelserver-jsonforms-property-view/package.json
@@ -28,11 +28,9 @@
   "dependencies": {
     "@eclipse-emfcloud/jsonforms-property-view": "0.7.0",
     "@eclipse-emfcloud/modelserver-client": "next",
-    "@eclipse-emfcloud/modelserver-theia": "next",
-    "urijs": "^1.19.11"
+    "@eclipse-emfcloud/modelserver-theia": "next"
   },
   "devDependencies": {
-    "@types/urijs": "^1.19.19",
     "rimraf": "^2.6.1",
     "typescript": "^4.6.3"
   },

--- a/modelserver-jsonforms-property-view/src/browser/modelserver-widget-provider.ts
+++ b/modelserver-jsonforms-property-view/src/browser/modelserver-widget-provider.ts
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2021-2022 EclipseSource and others.
+ * Copyright (c) 2021-2023 EclipseSource and others.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0 which is available at
@@ -13,9 +13,9 @@ import { IncrementalUpdateNotificationV2, Operations } from '@eclipse-emfcloud/m
 import { TheiaModelServerClientV2 } from '@eclipse-emfcloud/modelserver-theia';
 import { ModelServerSubscriptionServiceV2 } from '@eclipse-emfcloud/modelserver-theia/lib/browser';
 import { SelectionService } from '@theia/core/lib/common/selection-service';
+import URI from '@theia/core/lib/common/uri';
 import { inject, injectable, postConstruct } from 'inversify';
 import { debounce } from 'lodash';
-import * as URI from 'urijs';
 
 @injectable()
 export abstract class ModelserverAwareWidgetProvider extends JsonFormsPropertyViewWidgetProvider {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3205,11 +3205,6 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.2.tgz#fc25ad9943bcac11cceb8168db4f275e0e72e756"
   integrity sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==
 
-"@types/urijs@^1.19.19":
-  version "1.19.19"
-  resolved "https://registry.yarnpkg.com/@types/urijs/-/urijs-1.19.19.tgz#2789369799907fc11e2bc6e3a00f6478c2281b95"
-  integrity sha512-FDJNkyhmKLw7uEvTxx5tSXfPeQpO0iy73Ry+PmYZJvQy0QIWX8a7kJ4kLWRf+EbTPJEPDSgPXHaM7pzr5lmvCg==
-
 "@types/uuid@^7.0.3":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-7.0.5.tgz#b1d2f772142a301538fae9bdf9cf15b9f2573a29"
@@ -10968,11 +10963,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-urijs@^1.19.11:
-  version "1.19.11"
-  resolved "https://registry.yarnpkg.com/urijs/-/urijs-1.19.11.tgz#204b0d6b605ae80bea54bea39280cdb7c9f923cc"
-  integrity sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ==
 
 url-parse@^1.5.3:
   version "1.5.10"


### PR DESCRIPTION
- Use Theia's URI type in ModelserverAwareWidgetProvider to store currentModelUri
- Remove urijs and @types/urijs dependencies

Resolves #40

Contributed on behalf of STMicroelectronics